### PR TITLE
Comment out link to JAMR until ready

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -92,7 +92,7 @@ of the <a href="http://nhshackday.com">NHS Hack Day</a> community.</p>
 
 <ul>
   <li><a href="http://opal.openhealthcare.org.uk">Opal</a></li>
-  <li><a href="http://www.nsamr.ac.uk/journal/">JAMR</a></li>
+  <!-- <li><a href="http://www.nsamr.ac.uk/journal/">JAMR</a></li> -->
   <li><a href="http://www.openeyes.org.uk/">Open Eyes</a></li>
 </ul>
 


### PR DESCRIPTION
The current link to JAMR is broken and the domain is currently just a bootstrap wordpress site - there is no information about what it is.

It might be best to comment this link out until there is something of interest on the end of it.